### PR TITLE
Fix :heart_exclamation: emoji name

### DIFF
--- a/src/main/resources/emojis.yml
+++ b/src/main/resources/emojis.yml
@@ -99,7 +99,7 @@ emojis:
   ⌚:
     name: watch
   ❣:
-    name: heart_exclamation
+    name: heart_dot
   ⛈:
     name: lightning_rain
   ↔:


### PR DESCRIPTION
The :heart_exclamation: emoji name is too long for the plugin in the default configurtion. With the intent to remove confusion for people using this plugin, the emoji name was changed from heart_exclamation, to heart_dot.